### PR TITLE
Add ai autocomplete

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -1,5 +1,4 @@
 -- completion engine
-
 return {
   'hrsh7th/nvim-cmp',
   event = 'InsertEnter',
@@ -11,8 +10,25 @@ return {
   },
   config = function()
     local cmp = require 'cmp'
+
     cmp.setup {
-      mapping = cmp.mapping.preset.insert {},
+      snippet = {
+        expand = function(args)
+          require('luasnip').lsp_expand(args.body)
+        end,
+      },
+
+      mapping = cmp.mapping.preset.insert {
+        ['<C-n>'] = cmp.mapping.select_next_item {},
+        ['<C-p>'] = cmp.mapping.select_prev_item {},
+        ['<CR>'] = cmp.mapping.confirm { select = true },
+      },
+
+      window = {
+        completion = cmp.config.window.bordered(),
+        documentation = cmp.config.window.bordered(),
+      },
+
       sources = cmp.config.sources {
         { name = 'codeium' },
         { name = 'nvim_lsp' },

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -14,6 +14,7 @@ return {
     cmp.setup {
       mapping = cmp.mapping.preset.insert {},
       sources = cmp.config.sources {
+        { name = 'codeium' },
         { name = 'nvim_lsp' },
         { name = 'path' },
         { name = 'buffer' },

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -19,8 +19,12 @@ return {
       },
 
       mapping = cmp.mapping.preset.insert {
-        ['<C-n>'] = cmp.mapping.select_next_item {},
-        ['<C-p>'] = cmp.mapping.select_prev_item {},
+        ['<C-n>'] = cmp.mapping.select_next_item {
+          behavior = cmp.SelectBehavior.Select,
+        },
+        ['<C-p>'] = cmp.mapping.select_prev_item {
+          behavior = cmp.SelectBehavior.Select,
+        },
         ['<CR>'] = cmp.mapping.confirm { select = true },
       },
 

--- a/lua/plugins/codeium.lua
+++ b/lua/plugins/codeium.lua
@@ -1,0 +1,12 @@
+-- Windsurf to add ai autocomplete
+
+return {
+  'Exafunction/windsurf.nvim',
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+    'hrsh7th/nvim-cmp',
+  },
+  config = function()
+    require('codeium').setup {}
+  end,
+}


### PR DESCRIPTION
Added Windsurf ai inline autocomplete to nvim:
- Installed the windsurf dependency
- Attached it to nvim.cmp (autocomplete)

<img width="2127" height="312" alt="image" src="https://github.com/user-attachments/assets/9d5e5a64-90ec-4b6e-990a-a1baf049a4d6" />

